### PR TITLE
Update juce_bluetooth.h

### DIFF
--- a/juce_bluetooth/juce_bluetooth.h
+++ b/juce_bluetooth/juce_bluetooth.h
@@ -14,7 +14,7 @@
   description:        Bluetooth LE classes for JUCE
 
   dependencies: juce_core, juce_data_structures
-  OSXFrameworks: CoreBluetooth, Foundation
+  OSXFrameworks: CoreBluetooth Foundation
   mingwLibs: WindowsApp.lib, cppwinrt
   minimumCppStandard: 17
   searchpaths: include


### PR DESCRIPTION
The comma in the separation of `OSXFrameworks` creates an 'empty' or 'broken' framework to be added to JUCE projects. The JUCE documentation does say it can be comma separated but from this I don't think it can...