### PR TITLE
Make juce_bluetooth OSXFrameworks compatible with Projucer

### DIFF
--- a/juce_bluetooth/juce_bluetooth.h
+++ b/juce_bluetooth/juce_bluetooth.h
@@ -14,7 +14,7 @@
   description:        Bluetooth LE classes for JUCE
 
   dependencies: juce_core, juce_data_structures
-  OSXFrameworks: CoreBluetooth, Foundation
+  OSXFrameworks: CoreBluetooth Foundation
   windowsLibs: windowsapp
   linuxLibs: bluetooth, glib-2.0
   minimumCppStandard: 17


### PR DESCRIPTION
The Projucer hates commas in those lists so I got rid of the comma :)